### PR TITLE
add setter for change service url

### DIFF
--- a/src/Pond/Tunes/Search.php
+++ b/src/Pond/Tunes/Search.php
@@ -95,6 +95,19 @@ class Search extends Tunes
         return $results;
     }
 
+	/**
+	 * Setup URI for search service
+	 *
+	 * @param $uri
+	 * 
+	 * @return Search
+	 */
+	public function setServiceUrl($uri) {
+		$this->serviceUri = (string) $uri;
+
+		return $this;
+	}
+
     /**
      * {@inheritDoc}
      */


### PR DESCRIPTION
or changing variable $serviceUri to public will able me to use this library with Buzz HTTP client on production server.
I got affected by error mentioned [here](https://github.com/kriswallsmith/Buzz/issues/67). And i found fastest solution which doesn't use SSL in iTunes search service. 
